### PR TITLE
Update dependencies and CLI logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8866 @@
+{
+    "name": "@kachurun/create-solid-storybook",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@kachurun/create-solid-storybook",
+            "version": "0.0.0",
+            "license": "MIT",
+            "workspaces": [
+                "packages/*"
+            ],
+            "dependencies": {
+                "commander": "^14.0.0",
+                "tar": "^7.4.3"
+            },
+            "devDependencies": {
+                "@changesets/changelog-github": "^0.5.1",
+                "@changesets/cli": "^2.29.5",
+                "@flexbe/eslint-config": "^1.0.11",
+                "@tsconfig/strictest": "^2.0.5",
+                "acorn-walk": "^8.3.4",
+                "bun": "^1.2.14",
+                "eslint": "^9.30.1",
+                "tsup": "^8.5.0",
+                "turbo": "^2.5.4"
+            }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.4.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@ampproject/remapping": {
+            "version": "2.3.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@antfu/eslint-config": {
+            "version": "4.13.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@antfu/install-pkg": "^1.1.0",
+                "@clack/prompts": "^0.10.1",
+                "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
+                "@eslint/markdown": "^6.4.0",
+                "@stylistic/eslint-plugin": "^4.2.0",
+                "@typescript-eslint/eslint-plugin": "^8.32.0",
+                "@typescript-eslint/parser": "^8.32.0",
+                "@vitest/eslint-plugin": "^1.1.44",
+                "ansis": "^3.17.0",
+                "cac": "^6.7.14",
+                "eslint-config-flat-gitignore": "^2.1.0",
+                "eslint-flat-config-utils": "^2.0.1",
+                "eslint-merge-processors": "^2.0.0",
+                "eslint-plugin-antfu": "^3.1.1",
+                "eslint-plugin-command": "^3.2.0",
+                "eslint-plugin-import-x": "^4.11.0",
+                "eslint-plugin-jsdoc": "^50.6.11",
+                "eslint-plugin-jsonc": "^2.20.0",
+                "eslint-plugin-n": "^17.17.0",
+                "eslint-plugin-no-only-tests": "^3.3.0",
+                "eslint-plugin-perfectionist": "^4.12.3",
+                "eslint-plugin-pnpm": "^0.3.1",
+                "eslint-plugin-regexp": "^2.7.0",
+                "eslint-plugin-toml": "^0.12.0",
+                "eslint-plugin-unicorn": "^59.0.1",
+                "eslint-plugin-unused-imports": "^4.1.4",
+                "eslint-plugin-vue": "^10.1.0",
+                "eslint-plugin-yml": "^1.18.0",
+                "eslint-processor-vue-blocks": "^2.0.0",
+                "globals": "^16.0.0",
+                "jsonc-eslint-parser": "^2.4.0",
+                "local-pkg": "^1.1.1",
+                "parse-gitignore": "^2.0.0",
+                "toml-eslint-parser": "^0.10.0",
+                "vue-eslint-parser": "^10.1.3",
+                "yaml-eslint-parser": "^1.3.0"
+            },
+            "bin": {
+                "eslint-config": "bin/index.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@eslint-react/eslint-plugin": "^1.38.4",
+                "@prettier/plugin-xml": "^3.4.1",
+                "@unocss/eslint-plugin": ">=0.50.0",
+                "astro-eslint-parser": "^1.0.2",
+                "eslint": "^9.10.0",
+                "eslint-plugin-astro": "^1.2.0",
+                "eslint-plugin-format": ">=0.1.0",
+                "eslint-plugin-react-hooks": "^5.2.0",
+                "eslint-plugin-react-refresh": "^0.4.19",
+                "eslint-plugin-solid": "^0.14.3",
+                "eslint-plugin-svelte": ">=2.35.1",
+                "eslint-plugin-vuejs-accessibility": "^2.4.1",
+                "prettier-plugin-astro": "^0.14.0",
+                "prettier-plugin-slidev": "^1.0.5",
+                "svelte-eslint-parser": ">=0.37.0"
+            },
+            "peerDependenciesMeta": {
+                "@eslint-react/eslint-plugin": {
+                    "optional": true
+                },
+                "@prettier/plugin-xml": {
+                    "optional": true
+                },
+                "@unocss/eslint-plugin": {
+                    "optional": true
+                },
+                "astro-eslint-parser": {
+                    "optional": true
+                },
+                "eslint-plugin-astro": {
+                    "optional": true
+                },
+                "eslint-plugin-format": {
+                    "optional": true
+                },
+                "eslint-plugin-react-hooks": {
+                    "optional": true
+                },
+                "eslint-plugin-react-refresh": {
+                    "optional": true
+                },
+                "eslint-plugin-solid": {
+                    "optional": true
+                },
+                "eslint-plugin-svelte": {
+                    "optional": true
+                },
+                "eslint-plugin-vuejs-accessibility": {
+                    "optional": true
+                },
+                "prettier-plugin-astro": {
+                    "optional": true
+                },
+                "prettier-plugin-slidev": {
+                    "optional": true
+                },
+                "svelte-eslint-parser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@antfu/install-pkg": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "package-manager-detector": "^1.3.0",
+                "tinyexec": "^1.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@antfu/install-pkg/node_modules/package-manager-detector": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@antfu/install-pkg/node_modules/tinyexec": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/js-tokens": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.27.7",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.27.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ampproject/remapping": "^2.2.0",
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.27.5",
+                "@babel/helper-compilation-targets": "^7.27.2",
+                "@babel/helper-module-transforms": "^7.27.3",
+                "@babel/helpers": "^7.27.6",
+                "@babel/parser": "^7.27.7",
+                "@babel/template": "^7.27.2",
+                "@babel/traverse": "^7.27.7",
+                "@babel/types": "^7.27.7",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.27.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.27.5",
+                "@babel/types": "^7.27.3",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.27.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.27.2",
+                "@babel/helper-validator-option": "^7.27.1",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache/node_modules/yallist": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.27.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.27.3"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.27.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.27.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.27.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.27.7"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-jsx": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.27.6",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.27.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.27.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.27.5",
+                "@babel/parser": "^7.27.7",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.27.7",
+                "debug": "^4.3.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/globals": {
+            "version": "11.12.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.27.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@changesets/apply-release-plan": {
+            "version": "7.0.12",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/config": "^3.1.1",
+                "@changesets/get-version-range-type": "^0.4.0",
+                "@changesets/git": "^3.0.4",
+                "@changesets/should-skip-package": "^0.1.2",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "detect-indent": "^6.0.0",
+                "fs-extra": "^7.0.1",
+                "lodash.startcase": "^4.4.0",
+                "outdent": "^0.5.0",
+                "prettier": "^2.7.1",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.5.3"
+            }
+        },
+        "node_modules/@changesets/assemble-release-plan": {
+            "version": "6.0.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.1.3",
+                "@changesets/should-skip-package": "^0.1.2",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "semver": "^7.5.3"
+            }
+        },
+        "node_modules/@changesets/changelog-git": {
+            "version": "0.2.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0"
+            }
+        },
+        "node_modules/@changesets/changelog-github": {
+            "version": "0.5.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/get-github-info": "^0.6.0",
+                "@changesets/types": "^6.1.0",
+                "dotenv": "^8.1.0"
+            }
+        },
+        "node_modules/@changesets/cli": {
+            "version": "2.29.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/apply-release-plan": "^7.0.12",
+                "@changesets/assemble-release-plan": "^6.0.9",
+                "@changesets/changelog-git": "^0.2.1",
+                "@changesets/config": "^3.1.1",
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.1.3",
+                "@changesets/get-release-plan": "^4.0.13",
+                "@changesets/git": "^3.0.4",
+                "@changesets/logger": "^0.1.1",
+                "@changesets/pre": "^2.0.2",
+                "@changesets/read": "^0.6.5",
+                "@changesets/should-skip-package": "^0.1.2",
+                "@changesets/types": "^6.1.0",
+                "@changesets/write": "^0.4.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "ansi-colors": "^4.1.3",
+                "ci-info": "^3.7.0",
+                "enquirer": "^2.4.1",
+                "external-editor": "^3.1.0",
+                "fs-extra": "^7.0.1",
+                "mri": "^1.2.0",
+                "p-limit": "^2.2.0",
+                "package-manager-detector": "^0.2.0",
+                "picocolors": "^1.1.0",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.5.3",
+                "spawndamnit": "^3.0.1",
+                "term-size": "^2.1.0"
+            },
+            "bin": {
+                "changeset": "bin.js"
+            }
+        },
+        "node_modules/@changesets/config": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.1.3",
+                "@changesets/logger": "^0.1.1",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "fs-extra": "^7.0.1",
+                "micromatch": "^4.0.8"
+            }
+        },
+        "node_modules/@changesets/errors": {
+            "version": "0.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "extendable-error": "^0.1.5"
+            }
+        },
+        "node_modules/@changesets/get-dependents-graph": {
+            "version": "2.1.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "picocolors": "^1.1.0",
+                "semver": "^7.5.3"
+            }
+        },
+        "node_modules/@changesets/get-github-info": {
+            "version": "0.6.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dataloader": "^1.4.0",
+                "node-fetch": "^2.5.0"
+            }
+        },
+        "node_modules/@changesets/get-release-plan": {
+            "version": "4.0.13",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/assemble-release-plan": "^6.0.9",
+                "@changesets/config": "^3.1.1",
+                "@changesets/pre": "^2.0.2",
+                "@changesets/read": "^0.6.5",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3"
+            }
+        },
+        "node_modules/@changesets/get-version-range-type": {
+            "version": "0.4.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@changesets/git": {
+            "version": "3.0.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/errors": "^0.2.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "is-subdir": "^1.1.1",
+                "micromatch": "^4.0.8",
+                "spawndamnit": "^3.0.1"
+            }
+        },
+        "node_modules/@changesets/logger": {
+            "version": "0.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.1.0"
+            }
+        },
+        "node_modules/@changesets/parse": {
+            "version": "0.4.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0",
+                "js-yaml": "^3.13.1"
+            }
+        },
+        "node_modules/@changesets/parse/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@changesets/parse/node_modules/js-yaml/node_modules/argparse": {
+            "version": "1.0.10",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@changesets/pre": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/errors": "^0.2.0",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "fs-extra": "^7.0.1"
+            }
+        },
+        "node_modules/@changesets/read": {
+            "version": "0.6.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/git": "^3.0.4",
+                "@changesets/logger": "^0.1.1",
+                "@changesets/parse": "^0.4.1",
+                "@changesets/types": "^6.1.0",
+                "fs-extra": "^7.0.1",
+                "p-filter": "^2.1.0",
+                "picocolors": "^1.1.0"
+            }
+        },
+        "node_modules/@changesets/should-skip-package": {
+            "version": "0.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3"
+            }
+        },
+        "node_modules/@changesets/types": {
+            "version": "6.1.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@changesets/write": {
+            "version": "0.4.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0",
+                "fs-extra": "^7.0.1",
+                "human-id": "^4.1.1",
+                "prettier": "^2.7.1"
+            }
+        },
+        "node_modules/@chromatic-com/storybook": {
+            "version": "4.2.0-next.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@neoconfetti/react": "^1.0.0",
+                "chromatic": "^12.0.0",
+                "filesize": "^10.0.12",
+                "jsonfile": "^6.1.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0",
+                "yarn": ">=1.22.18"
+            },
+            "peerDependencies": {
+                "storybook": "^0.0.0-0 || ^9.0.0 || ^9.1.0-0 || ^9.2.0-0 || ^10.0.0-0"
+            }
+        },
+        "node_modules/@clack/core": {
+            "version": "0.4.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "sisteransi": "^1.0.5"
+            }
+        },
+        "node_modules/@clack/prompts": {
+            "version": "0.10.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@clack/core": "0.4.2",
+                "picocolors": "^1.0.0",
+                "sisteransi": "^1.0.5"
+            }
+        },
+        "node_modules/@dprint/formatter": {
+            "version": "0.3.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@dprint/markdown": {
+            "version": "0.17.8",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@dprint/toml": {
+            "version": "0.6.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@es-joy/jsdoccomment": {
+            "version": "0.50.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.6",
+                "@typescript-eslint/types": "^8.11.0",
+                "comment-parser": "1.4.1",
+                "esquery": "^1.6.0",
+                "jsdoc-type-pratt-parser": "~4.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.5",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+            "version": "4.5.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^4.0.0",
+                "ignore": "^5.2.4"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint-react/ast": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/eff": "1.52.2",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/typescript-estree": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/core": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/ast": "1.52.2",
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@eslint-react/shared": "1.52.2",
+                "@eslint-react/var": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/type-utils": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "birecord": "^0.1.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/eff": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/eslint-plugin": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@eslint-react/shared": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/type-utils": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "eslint-plugin-react-debug": "1.52.2",
+                "eslint-plugin-react-dom": "1.52.2",
+                "eslint-plugin-react-hooks-extra": "1.52.2",
+                "eslint-plugin-react-naming-convention": "1.52.2",
+                "eslint-plugin-react-web-api": "1.52.2",
+                "eslint-plugin-react-x": "1.52.2"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": "^4.9.5 || ^5.3.3"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": false
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@eslint-react/kit": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/eff": "1.52.2",
+                "@typescript-eslint/utils": "^8.34.0",
+                "ts-pattern": "^5.7.1",
+                "zod": "^3.25.63"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/shared": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@typescript-eslint/utils": "^8.34.0",
+                "ts-pattern": "^5.7.1",
+                "zod": "^3.25.63"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/var": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/ast": "1.52.2",
+                "@eslint-react/eff": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint/compat": {
+            "version": "1.3.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.40 || 9"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@eslint/config-array": {
+            "version": "0.21.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.6",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.3.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.14.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.12.4",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.0",
+                "minimatch": "^3.1.2",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.30.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            }
+        },
+        "node_modules/@eslint/markdown": {
+            "version": "6.6.0",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "examples/*"
+            ],
+            "dependencies": {
+                "@eslint/core": "^0.14.0",
+                "@eslint/plugin-kit": "^0.3.1",
+                "github-slugger": "^2.0.0",
+                "mdast-util-from-markdown": "^2.0.2",
+                "mdast-util-frontmatter": "^2.0.1",
+                "mdast-util-gfm": "^3.0.0",
+                "micromark-extension-frontmatter": "^2.0.0",
+                "micromark-extension-gfm": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.6",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.3.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.15.1",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+            "version": "0.15.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@flexbe/eslint-config": {
+            "version": "1.0.11",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@antfu/eslint-config": "4.13.0",
+                "@eslint-react/eslint-plugin": "^1.49.0",
+                "eslint": "^9.26.0",
+                "eslint-plugin-format": "^1.0.1",
+                "eslint-plugin-react-hooks": "^5.2.0",
+                "eslint-plugin-react-refresh": "^0.4.20",
+                "eslint-plugin-solid": "^0.14.5",
+                "typescript": "^5.8.3"
+            },
+            "peerDependencies": {
+                "eslint": "^9.26.0",
+                "typescript": "^5.8.3"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.6",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+            "version": "0.3.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+            "version": "0.6.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "glob": "^10.0.0",
+                "react-docgen-typescript": "^2.2.2"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.3.x",
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.12",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@kachurun/storybook-solid-template": {
+            "resolved": "packages/storybook-solid-template",
+            "link": true
+        },
+        "node_modules/@manypkg/find-root": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "@types/node": "^12.7.1",
+                "find-up": "^4.1.0",
+                "fs-extra": "^8.1.0"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/@types/node": {
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@manypkg/find-root/node_modules/find-up": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/find-up/node_modules/locate-path": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/find-up/node_modules/locate-path/node_modules/p-locate": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/fs-extra": {
+            "version": "8.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/fs-extra/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@manypkg/get-packages": {
+            "version": "1.1.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "@changesets/types": "^4.0.1",
+                "@manypkg/find-root": "^1.1.0",
+                "fs-extra": "^8.1.0",
+                "globby": "^11.0.0",
+                "read-yaml-file": "^1.1.0"
+            }
+        },
+        "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+            "version": "8.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/@manypkg/get-packages/node_modules/fs-extra/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@mdx-js/react": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdx": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16",
+                "react": ">=16"
+            }
+        },
+        "node_modules/@neoconfetti/react": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@oven/bun-darwin-aarch64": {
+            "version": "1.2.17",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@pkgr/core": {
+            "version": "0.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts"
+            }
+        },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.29",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.44.1",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+            "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@storybook/addon-a11y": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.0.2.tgz",
+            "integrity": "sha512-iJJ+AXsi1oHOJ88lm/9Y2xoFJqkMOduORGk8VMPTE8fKO0THkBOSZboVHrPRiCADBLbkK9CIIzCoMzZd1XnakQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/global": "^5.0.0",
+                "axe-core": "^4.2.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "storybook": "^10.0.2"
+            }
+        },
+        "node_modules/@storybook/addon-docs": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.0.2.tgz",
+            "integrity": "sha512-0lU0kDKSLcKjTd+cQ2jwZr+vOIH/p0M6Vy6w/uoc6qsKEb/Plc+IHu+o2SU6ZO9hkVlDyXzk6xI+64N22O7CHg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/react": "^3.0.0",
+                "@storybook/csf-plugin": "10.0.2",
+                "@storybook/icons": "^1.6.0",
+                "@storybook/react-dom-shim": "10.0.2",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "ts-dedent": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "storybook": "^10.0.2"
+            }
+        },
+        "node_modules/@storybook/addon-links": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-10.0.2.tgz",
+            "integrity": "sha512-54QkYtyBfOzLJmQohnoL4fR8RGuw42fUvsX9qzyAxnd2PIcSK7eFo4L03S70l3WhuYbRzOo/Zem715nR2fVmuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/global": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "storybook": "^10.0.2"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@storybook/addon-onboarding": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-onboarding/-/addon-onboarding-10.0.2.tgz",
+            "integrity": "sha512-fpNdgFn+8AfLnB4bltCrVWR4yTOR6JReaVw1+WgN/L75mjkxbmB/7dvh5NdeDKHLiry0h50BukjkgERsqTsWEw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "storybook": "^10.0.2"
+            }
+        },
+        "node_modules/@storybook/addon-vitest": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.0.2.tgz",
+            "integrity": "sha512-ilpjflHJPa0au4YX48QsOmrkWFFqBjzfOGwKEDY2jBYJRyCqsdYju2Jl9Uku2CIXnJJJHI+iGLngPL225yV4Lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/global": "^5.0.0",
+                "@storybook/icons": "^1.6.0",
+                "prompts": "^2.4.0",
+                "ts-dedent": "^2.2.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "^3.0.0 || ^4.0.0",
+                "@vitest/browser-playwright": "^4.0.0",
+                "@vitest/runner": "^3.0.0 || ^4.0.0",
+                "storybook": "^10.0.2",
+                "vitest": "^3.0.0 || ^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/runner": {
+                    "optional": true
+                },
+                "vitest": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@storybook/builder-vite": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.0.2.tgz",
+            "integrity": "sha512-VPCsSdY7AYFnB2GRfRkcBmRA8RQo7I15PTEoIuQg5pF9qDQpz6ykMR8mK5j0TtRXshQjen4HyKv6lYTfmEMdUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/csf-plugin": "10.0.2",
+                "ts-dedent": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "storybook": "^10.0.2",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            }
+        },
+        "node_modules/@storybook/csf-plugin": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.0.2.tgz",
+            "integrity": "sha512-fiDTgZQa6/vCIMDWm5b/Dy+8/YGHX7bHqdINTtdKRJlrZgxFOainYczR6kyf5nyu9RQouEX0NgSXvKLS0HyCyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "unplugin": "^2.3.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "esbuild": "*",
+                "rollup": "*",
+                "storybook": "^10.0.2",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "esbuild": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@storybook/global": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@storybook/icons": {
+            "version": "1.6.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
+            }
+        },
+        "node_modules/@storybook/react-dom-shim": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.0.2.tgz",
+            "integrity": "sha512-rVEwxwd9g6TDIIXzX73NPV+FF/WokNKMm1H6ATYBQ51wrxiEalHg/lPFdosoWAQ4dsLKkeSxxOpZy9375IXhGQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "storybook": "^10.0.2"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin": {
+            "version": "4.4.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/utils": "^8.32.1",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
+                "estraverse": "^5.3.0",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=9.0.0"
+            }
+        },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.0",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "chalk": "^4.1.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "6.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "chalk": "^3.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "lodash": "^4.17.21",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.6.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=7.21.4"
+            }
+        },
+        "node_modules/@tsconfig/strictest": {
+            "version": "2.0.5",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/babel__core": {
+            "version": "7.20.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.27.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.20.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.20.7"
+            }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*"
+            }
+        },
+        "node_modules/@types/debug": {
+            "version": "4.1.12",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/ms": "*"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/mdast": {
+            "version": "4.0.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/mdx": {
+            "version": "2.0.13",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "24.9.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.2.tgz",
+            "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "undici-types": "~7.16.0"
+            }
+        },
+        "node_modules/@types/react": {
+            "version": "19.1.8",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.35.1",
+                "@typescript-eslint/type-utils": "8.35.1",
+                "@typescript-eslint/utils": "8.35.1",
+                "@typescript-eslint/visitor-keys": "8.35.1",
+                "graphemer": "^1.4.0",
+                "ignore": "^7.0.0",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.35.1",
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.35.1",
+                "@typescript-eslint/types": "8.35.1",
+                "@typescript-eslint/typescript-estree": "8.35.1",
+                "@typescript-eslint/visitor-keys": "8.35.1",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.35.1",
+                "@typescript-eslint/types": "^8.35.1",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.35.1",
+                "@typescript-eslint/visitor-keys": "8.35.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "8.35.1",
+                "@typescript-eslint/utils": "8.35.1",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.35.1",
+                "@typescript-eslint/tsconfig-utils": "8.35.1",
+                "@typescript-eslint/types": "8.35.1",
+                "@typescript-eslint/visitor-keys": "8.35.1",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+            "version": "9.0.5",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.35.1",
+                "@typescript-eslint/types": "8.35.1",
+                "@typescript-eslint/typescript-estree": "8.35.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.35.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.35.1",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-darwin-arm64": {
+            "version": "1.9.2",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vitest/browser": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@testing-library/dom": "^10.4.0",
+                "@testing-library/user-event": "^14.6.1",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "magic-string": "^0.30.17",
+                "sirv": "^3.0.1",
+                "tinyrainbow": "^2.0.0",
+                "ws": "^8.18.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "playwright": "*",
+                "vitest": "3.2.4",
+                "webdriverio": "^7.0.0 || ^8.0.0 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "playwright": {
+                    "optional": true
+                },
+                "safaridriver": {
+                    "optional": true
+                },
+                "webdriverio": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/eslint-plugin": {
+            "version": "1.3.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/utils": "^8.24.1"
+            },
+            "peerDependencies": {
+                "eslint": ">= 8.57.0",
+                "typescript": ">= 5.0.0",
+                "vitest": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "vitest": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.2.4",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@vitest/utils": "3.2.4",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^4.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "loupe": "^3.1.4",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.17",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.27.5",
+                "@vue/shared": "3.5.17",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.17",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.5.17",
+                "@vue/shared": "3.5.17"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.17",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.27.5",
+                "@vue/compiler-core": "3.5.17",
+                "@vue/compiler-dom": "3.5.17",
+                "@vue/compiler-ssr": "3.5.17",
+                "@vue/shared": "3.5.17",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.17",
+                "postcss": "^8.5.6",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.17",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.17",
+                "@vue/shared": "3.5.17"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.17",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/acorn": {
+            "version": "8.15.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.2",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "6.12.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ansis": {
+            "version": "3.17.0",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/any-promise": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/are-docs-informative": {
+            "version": "0.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/ast-types": {
+            "version": "0.16.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul": {
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
+            "integrity": "sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "estree-walker": "^3.0.3",
+                "js-tokens": "^9.0.1"
+            }
+        },
+        "node_modules/axe-core": {
+            "version": "4.10.3",
+            "dev": true,
+            "license": "MPL-2.0",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/babel-plugin-jsx-dom-expressions": {
+            "version": "0.39.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "7.18.6",
+                "@babel/plugin-syntax-jsx": "^7.18.6",
+                "@babel/types": "^7.20.7",
+                "html-entities": "2.3.3",
+                "parse5": "^7.1.2",
+                "validate-html-nesting": "^1.2.1"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.20.12"
+            }
+        },
+        "node_modules/babel-plugin-jsx-dom-expressions/node_modules/@babel/helper-module-imports": {
+            "version": "7.18.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.18.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/babel-preset-solid": {
+            "version": "1.9.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "babel-plugin-jsx-dom-expressions": "^0.39.8"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/better-path-resolve": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-windows": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/birecord": {
+            "version": "0.1.1",
+            "dev": true,
+            "license": "(MIT OR Apache-2.0)"
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.25.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "caniuse-lite": "^1.0.30001726",
+                "electron-to-chromium": "^1.5.173",
+                "node-releases": "^2.0.19",
+                "update-browserslist-db": "^1.1.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/builtin-modules": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bun": {
+            "version": "1.2.17",
+            "cpu": [
+                "arm64",
+                "x64",
+                "aarch64"
+            ],
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "os": [
+                "darwin",
+                "linux",
+                "win32"
+            ],
+            "bin": {
+                "bun": "bin/bun.exe",
+                "bunx": "bin/bunx.exe"
+            },
+            "optionalDependencies": {
+                "@oven/bun-darwin-aarch64": "1.2.17",
+                "@oven/bun-darwin-x64": "1.2.17",
+                "@oven/bun-darwin-x64-baseline": "1.2.17",
+                "@oven/bun-linux-aarch64": "1.2.17",
+                "@oven/bun-linux-aarch64-musl": "1.2.17",
+                "@oven/bun-linux-x64": "1.2.17",
+                "@oven/bun-linux-x64-baseline": "1.2.17",
+                "@oven/bun-linux-x64-musl": "1.2.17",
+                "@oven/bun-linux-x64-musl-baseline": "1.2.17",
+                "@oven/bun-windows-x64": "1.2.17",
+                "@oven/bun-windows-x64-baseline": "1.2.17"
+            }
+        },
+        "node_modules/bundle-require": {
+            "version": "5.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "load-tsconfig": "^0.2.3"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "esbuild": ">=0.18"
+            }
+        },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001726",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/ccount": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chai": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/character-entities": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chardet": {
+            "version": "0.7.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/check-error": {
+            "version": "2.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "4.0.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/chownr": {
+            "version": "3.0.0",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/chromatic": {
+            "version": "12.2.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "chroma": "dist/bin.js",
+                "chromatic": "dist/bin.js",
+                "chromatic-cli": "dist/bin.js"
+            },
+            "peerDependencies": {
+                "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+                "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@chromatic-com/cypress": {
+                    "optional": true
+                },
+                "@chromatic-com/playwright": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "3.9.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/clean-regexp": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/clean-regexp/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/commander": {
+            "version": "14.0.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/comment-parser": {
+            "version": "1.4.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/compare-versions": {
+            "version": "6.1.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/confbox": {
+            "version": "0.2.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/consola": {
+            "version": "3.4.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/core-js-compat": {
+            "version": "3.43.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.25.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
+            }
+        },
+        "node_modules/create-solid-storybook": {
+            "resolved": "packages/create-solid-storybook",
+            "link": true
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cssesc": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.1.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/dataloader": {
+            "version": "1.4.0",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/deep-is": {
+            "version": "0.1.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/detect-indent": {
+            "version": "6.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/devlop": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dequal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/dotenv": {
+            "version": "8.6.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.178",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.18.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/enquirer": {
+            "version": "2.4.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-colors": "^4.1.1",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/enquirer/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/enquirer/node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/esbuild": {
+            "version": "0.25.5",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.5",
+                "@esbuild/android-arm": "0.25.5",
+                "@esbuild/android-arm64": "0.25.5",
+                "@esbuild/android-x64": "0.25.5",
+                "@esbuild/darwin-arm64": "0.25.5",
+                "@esbuild/darwin-x64": "0.25.5",
+                "@esbuild/freebsd-arm64": "0.25.5",
+                "@esbuild/freebsd-x64": "0.25.5",
+                "@esbuild/linux-arm": "0.25.5",
+                "@esbuild/linux-arm64": "0.25.5",
+                "@esbuild/linux-ia32": "0.25.5",
+                "@esbuild/linux-loong64": "0.25.5",
+                "@esbuild/linux-mips64el": "0.25.5",
+                "@esbuild/linux-ppc64": "0.25.5",
+                "@esbuild/linux-riscv64": "0.25.5",
+                "@esbuild/linux-s390x": "0.25.5",
+                "@esbuild/linux-x64": "0.25.5",
+                "@esbuild/netbsd-arm64": "0.25.5",
+                "@esbuild/netbsd-x64": "0.25.5",
+                "@esbuild/openbsd-arm64": "0.25.5",
+                "@esbuild/openbsd-x64": "0.25.5",
+                "@esbuild/sunos-x64": "0.25.5",
+                "@esbuild/win32-arm64": "0.25.5",
+                "@esbuild/win32-ia32": "0.25.5",
+                "@esbuild/win32-x64": "0.25.5"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint": {
+            "version": "9.30.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.0",
+                "@eslint/config-helpers": "^0.3.0",
+                "@eslint/core": "^0.14.0",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.30.1",
+                "@eslint/plugin-kit": "^0.3.1",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "@types/json-schema": "^7.0.15",
+                "ajv": "^6.12.4",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.2",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-compat-utils": {
+            "version": "0.6.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-config-flat-gitignore": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint/compat": "^1.2.5"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "eslint": "^9.5.0"
+            }
+        },
+        "node_modules/eslint-flat-config-utils": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/eslint-formatting-reporter": {
+            "version": "0.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prettier-linter-helpers": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/eslint-import-context": {
+            "version": "0.1.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-tsconfig": "^4.10.1",
+                "stable-hash-x": "^0.2.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-import-context"
+            },
+            "peerDependencies": {
+                "unrs-resolver": "^1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "unrs-resolver": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-json-compat-utils": {
+            "version": "0.2.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esquery": "^1.6.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "eslint": "*",
+                "jsonc-eslint-parser": "^2.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@eslint/json": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-merge-processors": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "eslint": "*"
+            }
+        },
+        "node_modules/eslint-parser-plain": {
+            "version": "0.1.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eslint-plugin-antfu": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "eslint": "*"
+            }
+        },
+        "node_modules/eslint-plugin-command": {
+            "version": "3.3.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@es-joy/jsdoccomment": "^0.50.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "eslint": "*"
+            }
+        },
+        "node_modules/eslint-plugin-es-x": {
+            "version": "7.8.0",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/ota-meshi",
+                "https://opencollective.com/eslint"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.1.2",
+                "@eslint-community/regexpp": "^4.11.0",
+                "eslint-compat-utils": "^0.5.1"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8"
+            }
+        },
+        "node_modules/eslint-plugin-es-x/node_modules/eslint-compat-utils": {
+            "version": "0.5.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-format": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@dprint/formatter": "^0.3.0",
+                "@dprint/markdown": "^0.17.8",
+                "@dprint/toml": "^0.6.4",
+                "eslint-formatting-reporter": "^0.0.0",
+                "eslint-parser-plain": "^0.1.1",
+                "prettier": "^3.4.2",
+                "synckit": "^0.9.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "eslint": "^8.40.0 || ^9.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-format/node_modules/prettier": {
+            "version": "3.6.2",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/eslint-plugin-import-x": {
+            "version": "4.16.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "^8.35.0",
+                "comment-parser": "^1.4.1",
+                "debug": "^4.4.1",
+                "eslint-import-context": "^0.1.9",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.3 || ^10.0.1",
+                "semver": "^7.7.2",
+                "stable-hash-x": "^0.2.0",
+                "unrs-resolver": "^1.9.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-plugin-import-x"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/utils": "^8.0.0",
+                "eslint": "^8.57.0 || ^9.0.0",
+                "eslint-import-resolver-node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/utils": {
+                    "optional": true
+                },
+                "eslint-import-resolver-node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
+            "version": "9.0.5",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/eslint-plugin-import-x/node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-jsdoc": {
+            "version": "50.8.0",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@es-joy/jsdoccomment": "~0.50.2",
+                "are-docs-informative": "^0.0.2",
+                "comment-parser": "1.4.1",
+                "debug": "^4.4.1",
+                "escape-string-regexp": "^4.0.0",
+                "espree": "^10.3.0",
+                "esquery": "^1.6.0",
+                "parse-imports-exports": "^0.2.4",
+                "semver": "^7.7.2",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-jsonc": {
+            "version": "2.20.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.5.1",
+                "eslint-compat-utils": "^0.6.4",
+                "eslint-json-compat-utils": "^0.2.1",
+                "espree": "^9.6.1 || ^10.3.0",
+                "graphemer": "^1.4.0",
+                "jsonc-eslint-parser": "^2.4.0",
+                "natural-compare": "^1.4.0",
+                "synckit": "^0.6.2 || ^0.7.3 || ^0.11.5"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-jsonc/node_modules/synckit": {
+            "version": "0.11.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pkgr/core": "^0.2.4"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/synckit"
+            }
+        },
+        "node_modules/eslint-plugin-jsonc/node_modules/synckit/node_modules/@pkgr/core": {
+            "version": "0.2.7",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/pkgr"
+            }
+        },
+        "node_modules/eslint-plugin-n": {
+            "version": "17.20.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.5.0",
+                "@typescript-eslint/utils": "^8.26.1",
+                "enhanced-resolve": "^5.17.1",
+                "eslint-plugin-es-x": "^7.8.0",
+                "get-tsconfig": "^4.8.1",
+                "globals": "^15.11.0",
+                "ignore": "^5.3.2",
+                "minimatch": "^9.0.5",
+                "semver": "^7.6.3",
+                "ts-declaration-location": "^1.0.6"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.23.0"
+            }
+        },
+        "node_modules/eslint-plugin-n/node_modules/globals": {
+            "version": "15.15.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-plugin-n/node_modules/minimatch": {
+            "version": "9.0.5",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/eslint-plugin-n/node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-no-only-tests": {
+            "version": "3.3.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=5.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-perfectionist": {
+            "version": "4.15.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "^8.34.1",
+                "@typescript-eslint/utils": "^8.34.1",
+                "natural-orderby": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.45.0"
+            }
+        },
+        "node_modules/eslint-plugin-pnpm": {
+            "version": "0.3.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/antfu"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/sxzz"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "find-up-simple": "^1.0.1",
+                "jsonc-eslint-parser": "^2.4.0",
+                "pathe": "^2.0.3",
+                "pnpm-workspace-yaml": "0.3.1",
+                "tinyglobby": "^0.2.12",
+                "yaml-eslint-parser": "^1.3.0"
+            },
+            "peerDependencies": {
+                "eslint": "^9.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react-debug": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/ast": "1.52.2",
+                "@eslint-react/core": "1.52.2",
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@eslint-react/shared": "1.52.2",
+                "@eslint-react/var": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/type-utils": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": "^4.9.5 || ^5.3.3"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": false
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-react-dom": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/ast": "1.52.2",
+                "@eslint-react/core": "1.52.2",
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@eslint-react/shared": "1.52.2",
+                "@eslint-react/var": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "compare-versions": "^6.1.1",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": "^4.9.5 || ^5.3.3"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": false
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-react-hooks": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react-hooks-extra": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/ast": "1.52.2",
+                "@eslint-react/core": "1.52.2",
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@eslint-react/shared": "1.52.2",
+                "@eslint-react/var": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/type-utils": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": "^4.9.5 || ^5.3.3"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": false
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-react-naming-convention": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/ast": "1.52.2",
+                "@eslint-react/core": "1.52.2",
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@eslint-react/shared": "1.52.2",
+                "@eslint-react/var": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/type-utils": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": "^4.9.5 || ^5.3.3"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": false
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-react-refresh": {
+            "version": "0.4.20",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "eslint": ">=8.40"
+            }
+        },
+        "node_modules/eslint-plugin-react-web-api": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/ast": "1.52.2",
+                "@eslint-react/core": "1.52.2",
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@eslint-react/shared": "1.52.2",
+                "@eslint-react/var": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": "^4.9.5 || ^5.3.3"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": false
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-react-x": {
+            "version": "1.52.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-react/ast": "1.52.2",
+                "@eslint-react/core": "1.52.2",
+                "@eslint-react/eff": "1.52.2",
+                "@eslint-react/kit": "1.52.2",
+                "@eslint-react/shared": "1.52.2",
+                "@eslint-react/var": "1.52.2",
+                "@typescript-eslint/scope-manager": "^8.34.0",
+                "@typescript-eslint/type-utils": "^8.34.0",
+                "@typescript-eslint/types": "^8.34.0",
+                "@typescript-eslint/utils": "^8.34.0",
+                "compare-versions": "^6.1.1",
+                "is-immutable-type": "^5.0.1",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.7.1"
+            },
+            "engines": {
+                "bun": ">=1.0.15",
+                "node": ">=18.18.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "ts-api-utils": "^2.1.0",
+                "typescript": "^4.9.5 || ^5.3.3"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": false
+                },
+                "ts-api-utils": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-regexp": {
+            "version": "2.9.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.11.0",
+                "comment-parser": "^1.4.0",
+                "jsdoc-type-pratt-parser": "^4.0.0",
+                "refa": "^0.12.1",
+                "regexp-ast-analysis": "^0.7.1",
+                "scslre": "^0.3.0"
+            },
+            "engines": {
+                "node": "^18 || >=20"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.44.0"
+            }
+        },
+        "node_modules/eslint-plugin-solid": {
+            "version": "0.14.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/utils": "^7.13.1 || ^8.0.0",
+                "estraverse": "^5.3.0",
+                "is-html": "^2.0.0",
+                "kebab-case": "^1.0.2",
+                "known-css-properties": "^0.30.0",
+                "style-to-object": "^1.0.6"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "typescript": ">=4.8.4"
+            }
+        },
+        "node_modules/eslint-plugin-toml": {
+            "version": "0.12.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "eslint-compat-utils": "^0.6.0",
+                "lodash": "^4.17.19",
+                "toml-eslint-parser": "^0.10.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-unicorn": {
+            "version": "59.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "@eslint-community/eslint-utils": "^4.5.1",
+                "@eslint/plugin-kit": "^0.2.7",
+                "ci-info": "^4.2.0",
+                "clean-regexp": "^1.0.0",
+                "core-js-compat": "^3.41.0",
+                "esquery": "^1.6.0",
+                "find-up-simple": "^1.0.1",
+                "globals": "^16.0.0",
+                "indent-string": "^5.0.0",
+                "is-builtin-module": "^5.0.0",
+                "jsesc": "^3.1.0",
+                "pluralize": "^8.0.0",
+                "regexp-tree": "^0.1.27",
+                "regjsparser": "^0.12.0",
+                "semver": "^7.7.1",
+                "strip-indent": "^4.0.0"
+            },
+            "engines": {
+                "node": "^18.20.0 || ^20.10.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+            },
+            "peerDependencies": {
+                "eslint": ">=9.22.0"
+            }
+        },
+        "node_modules/eslint-plugin-unicorn/node_modules/@eslint/plugin-kit": {
+            "version": "0.2.8",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.13.0",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/eslint-plugin-unicorn/node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+            "version": "0.13.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/eslint-plugin-unicorn/node_modules/ci-info": {
+            "version": "4.2.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/eslint-plugin-unused-imports": {
+            "version": "4.1.4",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+                "eslint": "^9.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/eslint-plugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-vue": {
+            "version": "10.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "natural-compare": "^1.4.0",
+                "nth-check": "^2.1.1",
+                "postcss-selector-parser": "^6.0.15",
+                "semver": "^7.6.3",
+                "xml-name-validator": "^4.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "vue-eslint-parser": "^10.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-yml": {
+            "version": "1.18.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.2",
+                "escape-string-regexp": "4.0.0",
+                "eslint-compat-utils": "^0.6.0",
+                "natural-compare": "^1.4.0",
+                "yaml-eslint-parser": "^1.2.1"
+            },
+            "engines": {
+                "node": "^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-processor-vue-blocks": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/compiler-sfc": "^3.3.0",
+                "eslint": ">=9.0.0"
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "8.4.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree": {
+            "version": "10.4.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/esquery": {
+            "version": "1.6.0",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "estraverse": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "5.3.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+            "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/exsolve": {
+            "version": "1.0.7",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/extendable-error": {
+            "version": "0.1.7",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/external-editor": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-diff": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fast-glob/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fastq": {
+            "version": "1.19.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fault": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "format": "^0.2.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/file-entry-cache": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flat-cache": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/filesize": {
+            "version": "10.1.6",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 10.4.0"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-up-simple": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/fix-dts-default-cjs-exports": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "magic-string": "^0.30.17",
+                "mlly": "^1.7.4",
+                "rollup": "^4.34.8"
+            }
+        },
+        "node_modules/flat-cache": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.3.3",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/format": {
+            "version": "0.2.2",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "7.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/fs-extra/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/fs-minipass": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.10.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
+        "node_modules/github-slugger": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/glob": {
+            "version": "10.4.5",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "6.0.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.5",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/globals": {
+            "version": "16.3.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/globby": {
+            "version": "11.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/html-entities": {
+            "version": "2.3.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/html-tags": {
+            "version": "3.3.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/human-id": {
+            "version": "4.1.1",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "human-id": "dist/cli.js"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "5.3.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-fresh/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/inline-style-parser": {
+            "version": "0.2.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-builtin-module": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "builtin-modules": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-html": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "html-tags": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-immutable-type": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@typescript-eslint/type-utils": "^8.0.0",
+                "ts-api-utils": "^2.0.0",
+                "ts-declaration-location": "^1.0.4"
+            },
+            "peerDependencies": {
+                "eslint": "*",
+                "typescript": ">=4.7.4"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-subdir": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "better-path-resolve": "1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/is-what": {
+            "version": "4.1.16",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
+        "node_modules/is-windows": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-source-maps": {
+            "version": "5.0.6",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.23",
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/joycon": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "9.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdoc-type-pratt-parser": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/jsonc-eslint-parser": {
+            "version": "2.4.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.5.0",
+                "eslint-visitor-keys": "^3.0.0",
+                "espree": "^9.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/espree": {
+            "version": "9.6.1",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.9.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonfile/node_modules/universalify": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/kebab-case": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/kleur": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/known-css-properties": {
+            "version": "0.30.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/levn": {
+            "version": "0.4.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lilconfig": {
+            "version": "3.1.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/load-tsconfig": {
+            "version": "0.2.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/local-pkg": {
+            "version": "1.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mlly": "^1.7.4",
+                "pkg-types": "^2.0.1",
+                "quansync": "^0.2.8"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.sortby": {
+            "version": "4.7.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.startcase": {
+            "version": "4.4.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/longest-streak": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/loupe": {
+            "version": "3.1.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.3.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.25.4",
+                "@babel/types": "^7.25.4",
+                "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/markdown-table": {
+            "version": "3.0.4",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace": {
+            "version": "3.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mdast-util-from-markdown": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-frontmatter": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "micromark-extension-frontmatter": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mdast-util-gfm": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-gfm-autolink-literal": "^2.0.0",
+                "mdast-util-gfm-footnote": "^2.0.0",
+                "mdast-util-gfm-strikethrough": "^2.0.0",
+                "mdast-util-gfm-table": "^2.0.0",
+                "mdast-util-gfm-task-list-item": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-autolink-literal": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-find-and-replace": "^3.0.0",
+                "micromark-util-character": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-footnote": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-strikethrough": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-table": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "markdown-table": "^3.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-task-list-item": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-phrasing": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown": {
+            "version": "2.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "unist-util-visit": "^5.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-string": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/merge-anything": {
+            "version": "5.1.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-what": "^4.1.8"
+            },
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromark": {
+            "version": "4.0.2",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-core-commonmark": {
+            "version": "2.0.3",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-frontmatter": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fault": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "micromark-extension-gfm-autolink-literal": "^2.0.0",
+                "micromark-extension-gfm-footnote": "^2.0.0",
+                "micromark-extension-gfm-strikethrough": "^2.0.0",
+                "micromark-extension-gfm-table": "^2.0.0",
+                "micromark-extension-gfm-tagfilter": "^2.0.0",
+                "micromark-extension-gfm-task-list-item": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-autolink-literal": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-footnote": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-strikethrough": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-table": {
+            "version": "2.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-tagfilter": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-task-list-item": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-factory-destination": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-label": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-space": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-title": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-whitespace": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-character": {
+            "version": "2.1.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-chunked": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-classify-character": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-combine-extensions": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "2.0.2",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-string": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-encode": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-resolve-all": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-sanitize-uri": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-subtokenize": {
+            "version": "2.1.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-symbol": {
+            "version": "2.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-types": {
+            "version": "2.0.2",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/mlly": {
+            "version": "1.7.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.14.0",
+                "pathe": "^2.0.1",
+                "pkg-types": "^1.3.0",
+                "ufo": "^1.5.4"
+            }
+        },
+        "node_modules/mlly/node_modules/pkg-types": {
+            "version": "1.3.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.1.8",
+                "mlly": "^1.7.4",
+                "pathe": "^2.0.1"
+            }
+        },
+        "node_modules/mlly/node_modules/pkg-types/node_modules/confbox": {
+            "version": "0.1.8",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mri": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/mrmime": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mz": {
+            "version": "2.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/napi-postinstall": {
+            "version": "0.2.5",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "napi-postinstall": "lib/cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/napi-postinstall"
+            }
+        },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/natural-orderby": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url/node_modules/tr46": {
+            "version": "0.0.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.19",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/optionator": {
+            "version": "0.9.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/outdent": {
+            "version": "0.5.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/p-filter": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-map": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "2.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate/node_modules/p-limit": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-map": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
+        "node_modules/package-manager-detector": {
+            "version": "0.2.11",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "quansync": "^0.2.7"
+            }
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-gitignore": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/parse-imports-exports": {
+            "version": "0.2.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse-statements": "1.0.11"
+            }
+        },
+        "node_modules/parse-statements": {
+            "version": "1.0.11",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pathval": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pify": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/pirates": {
+            "version": "4.0.7",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/pixelmatch": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
+            "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "pngjs": "^7.0.0"
+            },
+            "bin": {
+                "pixelmatch": "bin/pixelmatch"
+            }
+        },
+        "node_modules/pkg-types": {
+            "version": "2.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.2.2",
+                "exsolve": "^1.0.7",
+                "pathe": "^2.0.3"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.56.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+            "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/pluralize": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pngjs": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+            "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.19.0"
+            }
+        },
+        "node_modules/pnpm-workspace-yaml": {
+            "version": "0.3.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/antfu"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/sxzz"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "yaml": "^2.7.0"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.6",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/postcss-load-config": {
+            "version": "6.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "lilconfig": "^3.1.1"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "jiti": ">=1.21.0",
+                "postcss": ">=8.0.9",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/postcss-selector-parser": {
+            "version": "6.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "2.8.8",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/prettier-linter-helpers": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-diff": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/prompts": {
+            "version": "2.4.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/quansync": {
+            "version": "0.2.10",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/antfu"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/sxzz"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/react": {
+            "version": "19.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-docgen-typescript": {
+            "version": "2.4.0",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "typescript": ">= 4.3.x"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "19.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.26.0"
+            },
+            "peerDependencies": {
+                "react": "^19.1.0"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "17.0.2",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/read-yaml-file": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.5",
+                "js-yaml": "^3.6.1",
+                "pify": "^4.0.1",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/read-yaml-file/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/read-yaml-file/node_modules/js-yaml/node_modules/argparse": {
+            "version": "1.0.10",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/recast": {
+            "version": "0.23.11",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ast-types": "^0.16.1",
+                "esprima": "~4.0.0",
+                "source-map": "~0.6.1",
+                "tiny-invariant": "^1.3.3",
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/recast/node_modules/source-map": {
+            "version": "0.6.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/redent/node_modules/indent-string": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/redent/node_modules/strip-indent": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/refa": {
+            "version": "0.12.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.8.0"
+            },
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/regexp-ast-analysis": {
+            "version": "0.7.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.8.0",
+                "refa": "^0.12.1"
+            },
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/regexp-tree": {
+            "version": "0.1.27",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "regexp-tree": "bin/regexp-tree"
+            }
+        },
+        "node_modules/regjsparser": {
+            "version": "0.12.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "jsesc": "~3.0.2"
+            },
+            "bin": {
+                "regjsparser": "bin/parser"
+            }
+        },
+        "node_modules/regjsparser/node_modules/jsesc": {
+            "version": "3.0.2",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.44.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.44.1",
+                "@rollup/rollup-android-arm64": "4.44.1",
+                "@rollup/rollup-darwin-arm64": "4.44.1",
+                "@rollup/rollup-darwin-x64": "4.44.1",
+                "@rollup/rollup-freebsd-arm64": "4.44.1",
+                "@rollup/rollup-freebsd-x64": "4.44.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.44.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.44.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.44.1",
+                "@rollup/rollup-linux-arm64-musl": "4.44.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.44.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.44.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.44.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.44.1",
+                "@rollup/rollup-linux-x64-gnu": "4.44.1",
+                "@rollup/rollup-linux-x64-musl": "4.44.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.44.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.44.1",
+                "@rollup/rollup-win32-x64-msvc": "4.44.1",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/scheduler": {
+            "version": "0.26.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/scslre": {
+            "version": "0.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.8.0",
+                "refa": "^0.12.0",
+                "regexp-ast-analysis": "^0.7.0"
+            },
+            "engines": {
+                "node": "^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.7.2",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/seroval": {
+            "version": "1.3.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/seroval-plugins": {
+            "version": "1.3.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "seroval": "^1.0"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/signal-exit": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/sirv": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+            "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.24",
+                "mrmime": "^2.0.0",
+                "totalist": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/sisteransi": {
+            "version": "1.0.5",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/slash": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/solid-js": {
+            "version": "1.9.10",
+            "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.10.tgz",
+            "integrity": "sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.1.0",
+                "seroval": "~1.3.0",
+                "seroval-plugins": "~1.3.0"
+            }
+        },
+        "node_modules/solid-refresh": {
+            "version": "0.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/generator": "^7.23.6",
+                "@babel/helper-module-imports": "^7.22.15",
+                "@babel/types": "^7.23.6"
+            },
+            "peerDependencies": {
+                "solid-js": "^1.3"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.8.0-beta.0",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "whatwg-url": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/spawndamnit": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE",
+            "dependencies": {
+                "cross-spawn": "^7.0.5",
+                "signal-exit": "^4.0.1"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "dev": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.21",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/stable-hash-x": {
+            "version": "0.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "3.9.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/storybook": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.0.2.tgz",
+            "integrity": "sha512-Kjhw0J+N3CzHO6NIc0trzTtG5ov0wkMsnKjyVqBL9Zq+WORCrhAESFTnk4Wt2JEIu+FVgb7pae8csWUoHk2reA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/global": "^5.0.0",
+                "@storybook/icons": "^1.6.0",
+                "@testing-library/jest-dom": "^6.6.3",
+                "@testing-library/user-event": "^14.6.1",
+                "@vitest/expect": "3.2.4",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/spy": "3.2.4",
+                "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
+                "recast": "^0.23.5",
+                "semver": "^7.6.2",
+                "ws": "^8.18.0"
+            },
+            "bin": {
+                "storybook": "dist/bin/dispatcher.js"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "prettier": "^2 || ^3"
+            },
+            "peerDependenciesMeta": {
+                "prettier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/storybook-solidjs-vite": {
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/storybook-solidjs-vite/-/storybook-solidjs-vite-10.0.4.tgz",
+            "integrity": "sha512-5x7Q6Fkd5YoJUifkHRm1yrUcvL/xbelI2RyPDCcSaNl4TY9I6hetmSydF3kczSEecKejhEHYaLLduDltwO/Afw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@joshwooding/vite-plugin-react-docgen-typescript": "^0.6.1",
+                "@storybook/builder-vite": "^10.0.0",
+                "@storybook/global": "^5.0.0",
+                "vite-plugin-solid": "^2.11.8"
+            },
+            "peerDependencies": {
+                "solid-js": "^1.9.0",
+                "storybook": "^10.0.0",
+                "typescript": ">= 4.9.x",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/string-ts": {
+            "version": "2.2.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-bom": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/strip-indent": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-literal": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/style-to-object": {
+            "version": "1.0.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inline-style-parser": "0.2.4"
+            }
+        },
+        "node_modules/sucrase": {
+            "version": "3.35.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "commander": "^4.0.0",
+                "glob": "^10.3.10",
+                "lines-and-columns": "^1.1.6",
+                "mz": "^2.7.0",
+                "pirates": "^4.0.1",
+                "ts-interface-checker": "^0.1.9"
+            },
+            "bin": {
+                "sucrase": "bin/sucrase",
+                "sucrase-node": "bin/sucrase-node"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/sucrase/node_modules/commander": {
+            "version": "4.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/synckit": {
+            "version": "0.9.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pkgr/core": "^0.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "2.2.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar": {
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+            "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/term-size": {
+            "version": "2.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/thenify": {
+            "version": "3.3.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "node_modules/thenify-all": {
+            "version": "1.6.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "thenify": ">= 3.1.0 < 4"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "4.0.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/toml-eslint-parser": {
+            "version": "0.10.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
+        "node_modules/toml-eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/totalist": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
+        },
+        "node_modules/ts-api-utils": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
+            }
+        },
+        "node_modules/ts-declaration-location": {
+            "version": "1.0.7",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "ko-fi",
+                    "url": "https://ko-fi.com/rebeccastevens"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "picomatch": "^4.0.2"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.0.0"
+            }
+        },
+        "node_modules/ts-dedent": {
+            "version": "2.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.10"
+            }
+        },
+        "node_modules/ts-interface-checker": {
+            "version": "0.1.13",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/ts-pattern": {
+            "version": "5.7.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/tsup": {
+            "version": "8.5.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bundle-require": "^5.1.0",
+                "cac": "^6.7.14",
+                "chokidar": "^4.0.3",
+                "consola": "^3.4.0",
+                "debug": "^4.4.0",
+                "esbuild": "^0.25.0",
+                "fix-dts-default-cjs-exports": "^1.0.0",
+                "joycon": "^3.1.1",
+                "picocolors": "^1.1.1",
+                "postcss-load-config": "^6.0.1",
+                "resolve-from": "^5.0.0",
+                "rollup": "^4.34.8",
+                "source-map": "0.8.0-beta.0",
+                "sucrase": "^3.35.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.11",
+                "tree-kill": "^1.2.2"
+            },
+            "bin": {
+                "tsup": "dist/cli-default.js",
+                "tsup-node": "dist/cli-node.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@microsoft/api-extractor": "^7.36.0",
+                "@swc/core": "^1",
+                "postcss": "^8.4.12",
+                "typescript": ">=4.5.0"
+            },
+            "peerDependenciesMeta": {
+                "@microsoft/api-extractor": {
+                    "optional": true
+                },
+                "@swc/core": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/turbo": {
+            "version": "2.5.4",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "turbo": "bin/turbo"
+            },
+            "optionalDependencies": {
+                "turbo-darwin-64": "2.5.4",
+                "turbo-darwin-arm64": "2.5.4",
+                "turbo-linux-64": "2.5.4",
+                "turbo-linux-arm64": "2.5.4",
+                "turbo-windows-64": "2.5.4",
+                "turbo-windows-arm64": "2.5.4"
+            }
+        },
+        "node_modules/turbo-darwin-arm64": {
+            "version": "2.5.4",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/type-check": {
+            "version": "0.4.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.8.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/ufo": {
+            "version": "1.6.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/undici-types": {
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
+        "node_modules/unist-util-is": {
+            "version": "6.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-stringify-position": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit-parents": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "0.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/unplugin": {
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.10.tgz",
+            "integrity": "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "acorn": "^8.15.0",
+                "picomatch": "^4.0.3",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/unrs-resolver": {
+            "version": "1.9.2",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "napi-postinstall": "^0.2.4"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unrs-resolver"
+            },
+            "optionalDependencies": {
+                "@unrs/resolver-binding-android-arm-eabi": "1.9.2",
+                "@unrs/resolver-binding-android-arm64": "1.9.2",
+                "@unrs/resolver-binding-darwin-arm64": "1.9.2",
+                "@unrs/resolver-binding-darwin-x64": "1.9.2",
+                "@unrs/resolver-binding-freebsd-x64": "1.9.2",
+                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.9.2",
+                "@unrs/resolver-binding-linux-arm-musleabihf": "1.9.2",
+                "@unrs/resolver-binding-linux-arm64-gnu": "1.9.2",
+                "@unrs/resolver-binding-linux-arm64-musl": "1.9.2",
+                "@unrs/resolver-binding-linux-ppc64-gnu": "1.9.2",
+                "@unrs/resolver-binding-linux-riscv64-gnu": "1.9.2",
+                "@unrs/resolver-binding-linux-riscv64-musl": "1.9.2",
+                "@unrs/resolver-binding-linux-s390x-gnu": "1.9.2",
+                "@unrs/resolver-binding-linux-x64-gnu": "1.9.2",
+                "@unrs/resolver-binding-linux-x64-musl": "1.9.2",
+                "@unrs/resolver-binding-wasm32-wasi": "1.9.2",
+                "@unrs/resolver-binding-win32-arm64-msvc": "1.9.2",
+                "@unrs/resolver-binding-win32-ia32-msvc": "1.9.2",
+                "@unrs/resolver-binding-win32-x64-msvc": "1.9.2"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.1.3",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/validate-html-nesting": {
+            "version": "1.2.3",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/vite": {
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.25.0",
+                "fdir": "^6.4.6",
+                "picomatch": "^4.0.2",
+                "postcss": "^8.5.6",
+                "rollup": "^4.40.0",
+                "tinyglobby": "^0.2.14"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-node": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vite-plugin-solid": {
+            "version": "2.11.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.23.3",
+                "@types/babel__core": "^7.20.4",
+                "babel-preset-solid": "^1.8.4",
+                "merge-anything": "^5.1.7",
+                "solid-refresh": "^0.6.3",
+                "vitefu": "^1.0.4"
+            },
+            "peerDependencies": {
+                "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*",
+                "solid-js": "^1.7.2",
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@testing-library/jest-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/fsevents": {
+            "version": "2.3.3",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/vitefu": {
+            "version": "1.0.7",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "tests/deps/*",
+                "tests/projects/*"
+            ],
+            "peerDependencies": {
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+            },
+            "peerDependenciesMeta": {
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest": {
+            "version": "3.2.4",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.4",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/pretty-format": "^3.2.4",
+                "@vitest/runner": "3.2.4",
+                "@vitest/snapshot": "3.2.4",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.4",
+                "@vitest/ui": "3.2.4",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vue-eslint-parser": {
+            "version": "10.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
+                "esquery": "^1.6.0",
+                "semver": "^7.6.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "4.0.2",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/webpack-virtual-modules": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+            "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/whatwg-url": {
+            "version": "7.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.18.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "5.0.0",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.8.0",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            }
+        },
+        "node_modules/yaml-eslint-parser": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.0.0",
+                "yaml": "^2.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
+        "node_modules/yaml-eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.67",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zwitch": {
+            "version": "2.0.4",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "packages/create-solid-storybook": {
+            "version": "10.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^14.0.0",
+                "tar": "^7.4.3"
+            },
+            "bin": {
+                "create-solid-storybook": "cli.mjs"
+            },
+            "devDependencies": {
+                "fs-minipass": "^3.0.3"
+            },
+            "engines": {
+                "node": ">=20.19.0 || >=22.12.0"
+            }
+        },
+        "packages/storybook-solid-template": {
+            "name": "@kachurun/storybook-solid-template",
+            "version": "10.0.2",
+            "license": "MIT",
+            "devDependencies": {
+                "@chromatic-com/storybook": "^4.2.0-next.1",
+                "@storybook/addon-a11y": "^10.0.2",
+                "@storybook/addon-docs": "^10.0.2",
+                "@storybook/addon-links": "^10.0.2",
+                "@storybook/addon-onboarding": "^10.0.2",
+                "@storybook/addon-vitest": "^10.0.2",
+                "@vitest/browser": "^4.0.5",
+                "@vitest/browser-playwright": "^4.0.5",
+                "@vitest/coverage-v8": "^4.0.5",
+                "playwright": "^1.56.1",
+                "solid-js": "^1.9.10",
+                "storybook": "^10.0.2",
+                "storybook-solidjs-vite": "10.0.4",
+                "vitest": "^4.0.5"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/browser": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.0.5.tgz",
+            "integrity": "sha512-WqIm7lAm/Yx3TucvFPPmOjJ1NtQS3tm8N/r63eUufFNK28Fl0+qNfVoqrP7+ZPshBACOWXD2i678cDjdnhl6pA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/mocker": "4.0.5",
+                "@vitest/utils": "4.0.5",
+                "magic-string": "^0.30.19",
+                "pixelmatch": "7.1.0",
+                "pngjs": "^7.0.0",
+                "sirv": "^3.0.2",
+                "tinyrainbow": "^3.0.3",
+                "ws": "^8.18.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "vitest": "4.0.5"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/browser-playwright": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.0.5.tgz",
+            "integrity": "sha512-2ppt3/sMHSnfMnYJjgUqpPfv8hvWR9hhCiQpcI+0Ls5CpBKCxoYfKSNOexQu+65Y2CA+yoIW9MXKmG7AnX7jtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/browser": "4.0.5",
+                "@vitest/mocker": "4.0.5",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "playwright": "*",
+                "vitest": "4.0.5"
+            },
+            "peerDependenciesMeta": {
+                "playwright": {
+                    "optional": false
+                }
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/coverage-v8": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.5.tgz",
+            "integrity": "sha512-Yn5Dx0UVvllE3uatQw+ftObWtM/TjAOdbd8WvygaR04iyFXdNmtvZ/nJ2/JndyzfPQtbAWw0F+GJY5+lgM/7qg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^1.0.2",
+                "@vitest/utils": "4.0.5",
+                "ast-v8-to-istanbul": "^0.3.5",
+                "debug": "^4.4.3",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-lib-source-maps": "^5.0.6",
+                "istanbul-reports": "^3.2.0",
+                "magicast": "^0.3.5",
+                "std-env": "^3.9.0",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "4.0.5",
+                "vitest": "4.0.5"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/expect": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.5.tgz",
+            "integrity": "sha512-DJctLVlKoddvP/G389oGmKWNG6GD9frm2FPXARziU80Rjo7SIYxQzb2YFzmQ4fVD3Q5utUYY8nUmWrqsuIlIXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.0.5",
+                "@vitest/utils": "4.0.5",
+                "chai": "^6.0.1",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/mocker": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.5.tgz",
+            "integrity": "sha512-iYHIy72LfbK+mL5W8zXROp6oOcJKXWeKcNjcPPsqoa18qIEDrhB6/Z08o0wRajTd6SSSDNw8NCSIHVNOMpz0mw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.0.5",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.19"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/pretty-format": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.5.tgz",
+            "integrity": "sha512-t1T/sSdsYyNc5AZl0EMeD0jW9cpJe2cODP0R++ZQe1kTkpgrwEfxGFR/yCG4w8ZybizbXRTHU7lE8sTDD/QsGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/runner": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.5.tgz",
+            "integrity": "sha512-CQVVe+YEeKSiFBD5gBAmRDQglm4PnMBYzeTmt06t5iWtsUN9StQeeKhYCea/oaqBYilf8sARG6fSctUcEL/UmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.0.5",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/snapshot": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.5.tgz",
+            "integrity": "sha512-jfmSAeR6xYNEvcD+/RxFGA1bzpqHtkVhgxo2cxXia+Q3xX7m6GpZij07rz+WyQcA/xEGn4eIS1OItkMyWsGBmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.0.5",
+                "magic-string": "^0.30.19",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/spy": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.5.tgz",
+            "integrity": "sha512-TUmVQpAQign7r8+EnZsgTF3vY9BdGofTUge1rGNbnHn2IN3FChiQoT9lrPz7A7AVUZJU2LAZXl4v66HhsNMhoA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/@vitest/utils": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.5.tgz",
+            "integrity": "sha512-V5RndUgCB5/AfNvK9zxGCrRs99IrPYtMTIdUzJMMFs9nrmE5JXExIEfjVtUteyTRiLfCm+dCRMHf/Uu7Mm8/dg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.0.5",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/chai": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.0.tgz",
+            "integrity": "sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/tinyrainbow": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+            "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/storybook-solid-template/node_modules/vitest": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.5.tgz",
+            "integrity": "sha512-4H+J28MI5oeYgGg3h5BFSkQ1g/2GKK1IR8oorH3a6EQQbb7CwjbnyBjH4PGxw9/6vpwAPNzaeUMp4Js4WJmdXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.0.5",
+                "@vitest/mocker": "4.0.5",
+                "@vitest/pretty-format": "4.0.5",
+                "@vitest/runner": "4.0.5",
+                "@vitest/snapshot": "4.0.5",
+                "@vitest/spy": "4.0.5",
+                "@vitest/utils": "4.0.5",
+                "debug": "^4.4.3",
+                "es-module-lexer": "^1.7.0",
+                "expect-type": "^1.2.2",
+                "magic-string": "^0.30.19",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.0.3",
+                "vite": "^6.0.0 || ^7.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.0.5",
+                "@vitest/browser-preview": "4.0.5",
+                "@vitest/browser-webdriverio": "4.0.5",
+                "@vitest/ui": "4.0.5",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        }
+    }
+}

--- a/packages/create-solid-storybook/CHANGELOG.md
+++ b/packages/create-solid-storybook/CHANGELOG.md
@@ -1,5 +1,17 @@
 # create-solid-storybook
 
+## 10.0.3
+
+### Patch Changes
+
+-   chore: Fix deps
+
+## 10.0.2
+
+### Patch Changes
+
+-   Update to Storybook 10 and simplify config
+
 ## 10.0.1
 
 ### Patch Changes

--- a/packages/create-solid-storybook/CHANGELOG.md
+++ b/packages/create-solid-storybook/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-solid-storybook
 
+## 10.0.1
+
+### Patch Changes
+
+-   Storybook 10
+
 ## 10.0.0
 
 ### Major Changes

--- a/packages/create-solid-storybook/cli.mjs
+++ b/packages/create-solid-storybook/cli.mjs
@@ -25,9 +25,10 @@ const packages = [
     `@chromatic-com/storybook@${tag}`,
     'solid-js',
     '@vitest/coverage-v8',
-    'playwright',
     'vitest',
+    'playwright',
     '@vitest/browser',
+    `@vitest/browser-playwright`,
 ];
     
 program
@@ -211,6 +212,16 @@ function updatePackageJson(target) {
         ...packageJson.scripts || {},
         storybook: 'storybook dev -p 6006',
         'build-storybook': 'storybook build',
+    };
+
+    // Update imports
+    packageJson.imports = {
+        ...packageJson.imports || {},
+        '#*': [
+            './*',
+            './*.ts',
+            './*.tsx'
+        ]
     };
 
     writeFileSync(pkgJsonPath, JSON.stringify(packageJson, null, 2));

--- a/packages/create-solid-storybook/package.json
+++ b/packages/create-solid-storybook/package.json
@@ -2,7 +2,7 @@
     "name": "create-solid-storybook",
     "description": "Scaffold Storybook projects with SolidJS integration",
     "private": false,
-    "version": "10.0.0",
+    "version": "10.0.1",
     "main": "./cli.mjs",
     "scripts": {
         "build": "exit 0",
@@ -36,8 +36,7 @@
     },
     "homepage": "https://github.com/kachurun/create-solid-storybook#readme",
     "publishConfig": {
-        "access": "public",
-        "tag": "next"
+        "access": "public"
     },
     "bin": {
         "create-solid-storybook": "./cli.mjs"

--- a/packages/create-solid-storybook/package.json
+++ b/packages/create-solid-storybook/package.json
@@ -2,7 +2,7 @@
     "name": "create-solid-storybook",
     "description": "Scaffold Storybook projects with SolidJS integration",
     "private": false,
-    "version": "10.0.1",
+    "version": "10.0.3",
     "main": "./cli.mjs",
     "scripts": {
         "build": "exit 0",

--- a/packages/storybook-solid-template/.storybook/main.ts
+++ b/packages/storybook-solid-template/.storybook/main.ts
@@ -1,11 +1,8 @@
-import path from 'path';
 import { defineMain } from 'storybook-solidjs-vite';
 
-const getAbsolutePath = (packageName: string): string => path.dirname(import.meta.resolve(path.join(packageName, 'package.json'))).replace(/^file:\/\//, '');
- 
 export default defineMain({
     framework: {
-        name: getAbsolutePath("storybook-solidjs-vite"),
+        name: 'storybook-solidjs-vite',
         options: {
             // docgen: {
                 // Enabled by default, but you can configure or disable it:
@@ -14,11 +11,11 @@ export default defineMain({
         },
     },
     addons: [
-        getAbsolutePath('@storybook/addon-onboarding'),
-        getAbsolutePath('@storybook/addon-docs'),
-        getAbsolutePath('@storybook/addon-a11y'),
-        getAbsolutePath('@storybook/addon-links'),
-        getAbsolutePath('@storybook/addon-vitest'),
+        '@storybook/addon-onboarding',
+        '@storybook/addon-docs',
+        '@storybook/addon-a11y',
+        '@storybook/addon-links',
+        '@storybook/addon-vitest',
     ],
     stories: [
         '../stories/**/*.mdx',

--- a/packages/storybook-solid-template/CHANGELOG.md
+++ b/packages/storybook-solid-template/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kachurun/storybook-solid-template
 
+## 10.0.1
+
+### Patch Changes
+
+-   Storybook 10
+
 ## 10.0.0
 
 ### Major Changes

--- a/packages/storybook-solid-template/CHANGELOG.md
+++ b/packages/storybook-solid-template/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @kachurun/storybook-solid-template
 
+## 10.0.3
+
+### Patch Changes
+
+-   chore: Fix deps
+
+## 10.0.2
+
+### Patch Changes
+
+-   Update to Storybook 10 and simplify config
+
 ## 10.0.1
 
 ### Patch Changes

--- a/packages/storybook-solid-template/package.json
+++ b/packages/storybook-solid-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kachurun/storybook-solid-template",
-  "version": "10.0.1",
+  "version": "10.0.3",
   "author": "kachurun",
   "license": "MIT",
   "bugs": {
@@ -21,18 +21,19 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.2.0-next.1",
-    "@storybook/addon-a11y": "^10.0.0",
-    "@storybook/addon-docs": "^10.0.0",
-    "@storybook/addon-links": "^10.0.0",
-    "@storybook/addon-onboarding": "^10.0.0",
-    "@storybook/addon-vitest": "^10.0.0",
-    "@vitest/browser": "^3.2.4",
-    "@vitest/coverage-v8": "^3.2.4",
-    "playwright": "^1.55.0",
-    "storybook": "^10.0.0",
-    "storybook-solidjs-vite": "^10.0.0",
-    "solid-js": "^1.9.9",
-    "vitest": "^3.2.4"
+    "@storybook/addon-a11y": "^10.0.2",
+    "@storybook/addon-docs": "^10.0.2",
+    "@storybook/addon-links": "^10.0.2",
+    "@storybook/addon-onboarding": "^10.0.2",
+    "@storybook/addon-vitest": "^10.0.2",
+    "@vitest/browser": "^4.0.5",
+    "@vitest/browser-playwright": "^4.0.5",
+    "@vitest/coverage-v8": "^4.0.5",
+    "playwright": "^1.56.1",
+    "solid-js": "^1.9.10",
+    "storybook": "^10.0.2",
+    "storybook-solidjs-vite": "10.0.4",
+    "vitest": "^4.0.5"
   },
   "publishConfig": {
     "access": "public",
@@ -44,7 +45,6 @@
     "package.json",
     "tsconfig.json",
     "vite.config.ts",
-    "vitest.config.ts",
     "README.md",
     ".gitignore"
   ],

--- a/packages/storybook-solid-template/package.json
+++ b/packages/storybook-solid-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kachurun/storybook-solid-template",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "author": "kachurun",
   "license": "MIT",
   "bugs": {
@@ -21,22 +21,22 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.2.0-next.1",
-    "@storybook/addon-a11y": "^10.0.0-rc.0",
-    "@storybook/addon-docs": "^10.0.0-rc.0",
-    "@storybook/addon-links": "^10.0.0-rc.0",
-    "@storybook/addon-onboarding": "^10.0.0-rc.0",
-    "@storybook/addon-vitest": "^10.0.0-rc.0",
+    "@storybook/addon-a11y": "^10.0.0",
+    "@storybook/addon-docs": "^10.0.0",
+    "@storybook/addon-links": "^10.0.0",
+    "@storybook/addon-onboarding": "^10.0.0",
+    "@storybook/addon-vitest": "^10.0.0",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
     "playwright": "^1.55.0",
-    "storybook": "^10.0.0-rc.0",
-    "storybook-solidjs-vite": "^10.0.0-rc.0",
+    "storybook": "^10.0.0",
+    "storybook-solidjs-vite": "^10.0.0",
     "solid-js": "^1.9.9",
     "vitest": "^3.2.4"
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "latest"
   },
   "files": [
     ".storybook/**",

--- a/packages/storybook-solid-template/vite.config.ts
+++ b/packages/storybook-solid-template/vite.config.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { defineConfig } from 'vite';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
 
 const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
@@ -27,7 +28,7 @@ export default defineConfig({
                 browser: {
                     enabled: true,
                     headless: true,
-                    provider: 'playwright',
+                    provider: playwright(),
                     instances: [{
                         browser: 'chromium'
                     }]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps template/CLI versions, switches to stable Storybook 10 + Vitest 4 with playwright provider, simplifies Storybook config, and updates CLI to install new deps and add package imports.
> 
> - **create-solid-storybook (CLI)**
>   - Add installation of `@vitest/browser-playwright`; ensure `playwright`, `@vitest/browser`, and `vitest` are included.
>   - Inject `package.json` `imports` mapping for `#*` and set Storybook scripts.
>   - Bump version to `10.0.3`; adjust publish config.
> - **storybook-solid-template**
>   - Simplify `.storybook/main.ts` to use direct addon/framework names (remove path resolution helper).
>   - Update `vite.config.ts` to use `provider: playwright()` from `@vitest/browser-playwright`.
>   - Refresh dev deps to stable (`storybook@^10.0.2`, `storybook-solidjs-vite@10.0.4`, `vitest@^4.0.5`, `playwright@^1.56.1`, add `@vitest/browser-playwright`).
>   - Bump version to `10.0.3`; set publish tag to `latest`.
> - **Changelogs**: Add entries for `10.0.1–10.0.3` noting Storybook 10 updates and dependency fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a72f302c3a03712c0c0faa16eb5962971c5b54de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->